### PR TITLE
Support current versions of concat and stdlib.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 6.0.0"
     },
     {
       "name": "simp/simplib",
@@ -23,7 +23,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.1 < 5.0.0"
+      "version_requirement": ">= 4.25.1 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Modifies [metadata](https://github.com/simp/pupmod/simp/oath/tree/master/metadata.json) to prevent dependency errors when used with the current versions of [concat](https://github.com/puppetlabs/puppetlabs-concat/blob/master/metadata.json#L3) and [stdlib](https://github.com/puppetlabs/puppetlabs-stdlib/blob/master/metadata.json#L3).