### PR TITLE
(SIMP-10051) oath Add Puppet 7 acceptance test

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,9 +4,7 @@ fixtures:
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git
     concat: https://github.com/simp/puppetlabs-concat.git
     simplib: https://github.com/simp/pupmod-simp-simplib.git
-    sshkeys_core:
-      repo: https://github.com/simp/pupmod-puppetlabs-sshkeys_core.git
-      puppet_version: ">= 6.0.0"
+    sshkeys_core:  https://github.com/simp/pupmod-puppetlabs-sshkeys_core.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
   symlinks:
     oath: "#{source_dir}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -368,3 +368,9 @@ pup6.pe-oel-fips:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel-combined-x64]'
+
+pup7.x:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,default]'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -23,6 +23,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
* Add a Puppet 7 acceptance test
* Remove check for Puppet 6 in .fixtures.yml
* Fail acceptance tests if no examples are executed.

[SIMP-9666] #comment pupmod-simp-oddjob acceptance tests configured
SIMP-10051 #close

[SIMP-9666]: https://simp-project.atlassian.net/browse/SIMP-9666