### PR TITLE
[puppetsync] Add a REFERENCE.md freshness check to PR tests

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -70,6 +70,19 @@ jobs:
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
 
+  reference:
+    name: 'REFERENCE.md freshness'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: 'Install Ruby 3.4'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.9
+          bundler-cache: true
+      - name: 'Check REFERENCE.md freshness'
+        run: bundle exec rake validate:strings
+
   releng-checks:
     name: 'RELENG checks'
     runs-on: ubuntu-latest

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -84,7 +84,7 @@ Data type: `Simplib::PackageEnsure`
 
 Sets the value for resource => package, key => ensure.
 
-Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'present'})`
+Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'present' })`
 
 ##### <a name="-oath--oath_exclude_users"></a>`oath_exclude_users`
 


### PR DESCRIPTION
This patch updates pr_tests.yml from the reconciled puppetsync
template, whose `reference` job now fails when REFERENCE.md is out
of sync with the module's strings docs (`rake validate:strings`),
and regenerates REFERENCE.md so the new check starts green.

Repo-specific `jobs.acceptance` blocks are preserved as-is.