### PR TITLE
[puppetsync] Fix hiera.yaml write race in spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -126,9 +126,13 @@ RSpec.configure do |c|
       end
     end
 
-    File.open(c.hiera_config, 'w') do |f|
-      f.write data.to_yaml
-    end
+    # Write atomically (write + rename) — every parallel_spec worker runs
+    # this hook, and a truncating write here can be observed as an empty
+    # hiera.yaml by a catalogue compile in another worker, silently dropping
+    # all custom hieradata (simp/pupmod-simp-simplib#362)
+    tmpfile = "#{c.hiera_config}.#{Process.pid}"
+    File.write(tmpfile, data.to_yaml)
+    File.rename(tmpfile, c.hiera_config)
   end
   # rubocop:enable RSpec/BeforeAfterAll
 


### PR DESCRIPTION
Every parallel_spec worker's before(:all) hook rewrote the shared
spec/fixtures/hieradata/hiera.yaml in place; a catalogue compile in
another worker during the truncation window saw an empty hiera
config and silently dropped all custom hieradata, producing random
hieradata-not-applied spec failures across the fleet. hiera.yaml is
now written atomically (write + rename).

See simp/puppetsync#90; validated on simp/pupmod-simp-simplib#363.