### PR TITLE
[puppetsync] Update metadata.json dependency ranges from the Forge

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Aug 24 2026 Steven Pritchard <steve@sicura.us> - 1.0.2
+- [puppetsync] Update metadata.json dependency ranges from the Forge
+
 * Thu Jul 09 2026 Steven Pritchard <steve@sicura.us> - 1.0.1
 - Resolved puppet-lint manifest whitespace offenses
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-oath",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "https://github.com/simp/pupmod-simp-oath/graphs/contributors",
   "summary": "Installation and config for pam_oath rpm",
   "license": "Apache-2.0",
@@ -15,15 +15,15 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 6.4.0 < 10.0.0"
+      "version_requirement": ">= 6.4.0 < 11.0.0"
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 4.9.0 < 6.0.0"
+      "version_requirement": ">= 4.9.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 8.0.0 < 10.0.0"
+      "version_requirement": ">= 8.0.0 < 11.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This patch updates the module's dependency version ranges (including
simp.optional_dependencies) against the Puppet Forge's current
releases: modules that moved are renamed per their superseded_by
chain, and upper version bounds are raised to '< next major' where
the current release fell outside the declared range. Lower bounds
and in-range requirements are untouched. The module version is
bumped (with a matching CHANGELOG entry) so RELENG checks pass.